### PR TITLE
enhance state management for request after edited/approved/rejected

### DIFF
--- a/src/modules/@layout/components/pages/singlePage/SinglePage.ts
+++ b/src/modules/@layout/components/pages/singlePage/SinglePage.ts
@@ -36,6 +36,7 @@ export interface SingleConfig<Tresponse, Tinner> {
   moreOptions?: (props: Tinner, state: SingleState, callback: SingleHandler) => IAppBarMenu[];
   showActionCentre?: boolean | false;
   onDataLoad: (props: Tinner, callback: SingleHandler, forceReload?: boolean | false) => void;
+  onDataLoaded?: (props: Tinner) => void;
   onUpdated: (props: Tinner, callback: SingleHandler) => void;
   primaryComponent: (data: Tresponse, props: Tinner) => JSX.Element;
   secondaryComponents: (data: Tresponse, props: Tinner) => JSX.Element[];
@@ -44,6 +45,7 @@ export interface SingleConfig<Tresponse, Tinner> {
 interface OwnOption {
   config: SingleConfig<any, any>;
   connectedProps: any;
+  shouldDataReload?: boolean;
 }
 
 interface OwnState {
@@ -177,6 +179,13 @@ const lifecycles: ReactLifeCycleFunctions<SinglePageProps, OwnState> = {
       }
     }
 
+    // track reload request from child
+    if (this.props.shouldDataReload !== prevProps.shouldDataReload) {
+      if (this.props.shouldDataReload) {
+        this.props.config.onDataLoad(this.props.connectedProps, this.props, true);
+      }
+    }
+
     // track inner props changes
     if (this.props.connectedProps !== prevProps.connectedProps) {  
       this.props.config.onUpdated(this.props.connectedProps, this.props);
@@ -184,6 +193,11 @@ const lifecycles: ReactLifeCycleFunctions<SinglePageProps, OwnState> = {
 
     // track response changes
     if (this.props.response !== prevProps.response) {
+      // call after receive any response 
+      if (this.props.config.onDataLoaded) {
+        this.props.config.onDataLoaded(this.props.connectedProps);
+      }
+
       // assign more menu items
       if (this.props.config.hasMore && this.props.config.moreOptions) {
         const menuOptions = this.props.config.moreOptions(this.props.connectedProps, this.props, this.props);

--- a/src/modules/project/components/approval/detail/ProjectApprovalDetailView.tsx
+++ b/src/modules/project/components/approval/detail/ProjectApprovalDetailView.tsx
@@ -62,9 +62,14 @@ const config: SingleConfig<IProjectDetail, ProjectApprovalDetailProps> = {
       }
     }
   },
-  onUpdated: (states: ProjectApprovalDetailProps, callback: SingleHandler) => {
-    const { isLoading, response } = states.projectApprovalState.detail;
+  onDataLoaded: (props: ProjectApprovalDetailProps) => {
+    // set data loaded in local state
+    props.setDataload();
+  },
+  onUpdated: (props: ProjectApprovalDetailProps, callback: SingleHandler) => {
+    const { isLoading, response } = props.projectApprovalState.detail;
     
+    // set loading status
     callback.handleLoading(isLoading);
 
     // when got a response from api
@@ -116,5 +121,6 @@ export const ProjectApprovalDetailView: React.SFC<ProjectApprovalDetailProps> = 
   <SinglePage
     config={config}
     connectedProps={props}
+    shouldDataReload={props.shouldDataReload}
   />
 );

--- a/src/modules/project/components/registration/detail/ProjectRegistrationDetailView.tsx
+++ b/src/modules/project/components/registration/detail/ProjectRegistrationDetailView.tsx
@@ -101,8 +101,8 @@ const config: SingleConfig<IProjectDetail, ProjectRegistrationDetailProps> = {
       }
     }
   },
-  onUpdated: (states: ProjectRegistrationDetailProps, callback: SingleHandler) => {
-    const { isLoading, response } = states.projectRegisterState.detail;
+  onUpdated: (props: ProjectRegistrationDetailProps, callback: SingleHandler) => {
+    const { isLoading, response } = props.projectRegisterState.detail;
     
     callback.handleLoading(isLoading);
 

--- a/src/modules/project/store/sagas/projectAcceptanceSagas.ts
+++ b/src/modules/project/store/sagas/projectAcceptanceSagas.ts
@@ -1,6 +1,7 @@
-import { layoutAlertAdd, listBarLoading, listBarMetadata } from '@layout/store/actions';
+import { layoutAlertAdd } from '@layout/store/actions';
 import {
   ProjectAcceptanceAction as Action,
+  projectAcceptanceGetAllDispose,
   projectAcceptanceGetAllError,
   projectAcceptanceGetAllRequest,
   projectAcceptanceGetAllSuccess,
@@ -29,8 +30,7 @@ function* watchGetAllRequest() {
       method: 'get',
       path: `/v1/project/assignments/acceptances?${params}`,
       successEffects: (response: IApiResponse) => [
-        put(projectAcceptanceGetAllSuccess(response.body)),
-        put(listBarMetadata(response.body.metadata))
+        put(projectAcceptanceGetAllSuccess(response.body))
       ],
       failureEffects: (response: IApiResponse) => [
         put(projectAcceptanceGetAllError(response.body)),
@@ -51,7 +51,9 @@ function* watchGetAllRequest() {
           })
         )
       ],
-      finallyEffects: [put(listBarLoading(false))]
+      finallyEffects: [
+        // nothing
+      ]
     });
   };
 
@@ -98,7 +100,8 @@ function* watchPostRequest() {
       path: `/v1/project/assignments/acceptances/${action.payload.assignmentUid}/${action.payload.assignmentItemUid}`,
       payload: action.payload.data,
       successEffects: (response: IApiResponse) => [
-        put(projectAcceptancePostSuccess(response.body))
+        put(projectAcceptancePostSuccess(response.body)),
+        put(projectAcceptanceGetAllDispose())
       ],
       successCallback: (response: IApiResponse) => {
         action.payload.resolve(response.body.data);

--- a/src/modules/project/store/sagas/projectApprovalSagas.ts
+++ b/src/modules/project/store/sagas/projectApprovalSagas.ts
@@ -1,6 +1,7 @@
-import { layoutAlertAdd, listBarLoading, listBarMetadata } from '@layout/store/actions';
+import { layoutAlertAdd } from '@layout/store/actions';
 import {
   ProjectApprovalAction as Action,
+  projectApprovalGetAllDispose,
   projectApprovalGetAllError,
   projectApprovalGetAllRequest,
   projectApprovalGetAllSuccess,
@@ -30,7 +31,6 @@ function* watchGetAllRequest() {
       path: `/v1/approvals/project?${params}`,
       successEffects: (response: IApiResponse) => [
         put(projectApprovalGetAllSuccess(response.body)),
-        put(listBarMetadata(response.body.metadata))
       ],
       failureEffects: (response: IApiResponse) => [
         put(projectApprovalGetAllError(response.body)),
@@ -51,7 +51,9 @@ function* watchGetAllRequest() {
           })
         )
       ],
-      finallyEffects: [put(listBarLoading(false))]
+      finallyEffects: [
+        // nothing
+      ]
     });
   };
 
@@ -98,7 +100,8 @@ function* watchPostRequest() {
       path: `/v1/approvals/project/${action.payload.companyUid}/${action.payload.positionUid}/${action.payload.projectUid}`,
       payload: action.payload.data,
       successEffects: (response: IApiResponse) => [
-        put(projectApprovalPostSuccess(response.body))
+        put(projectApprovalPostSuccess(response.body)),
+        put(projectApprovalGetAllDispose())
       ],
       successCallback: (response: IApiResponse) => {
         action.payload.resolve(response.body.data);

--- a/src/modules/project/store/sagas/projectAssignmentSagas.ts
+++ b/src/modules/project/store/sagas/projectAssignmentSagas.ts
@@ -1,6 +1,7 @@
-import { layoutAlertAdd, listBarLoading, listBarMetadata } from '@layout/store/actions';
+import { layoutAlertAdd } from '@layout/store/actions';
 import {
   ProjectAssignmentAction as Action,
+  projectAssignmentGetAllDispose,
   projectAssignmentGetAllError,
   projectAssignmentGetAllRequest,
   projectAssignmentGetAllSuccess,
@@ -26,8 +27,7 @@ function* watchGetAllRequest() {
       method: 'get',
       path: `/v1/project/assignments${objectToQuerystring(action.payload.filter)}`,
       successEffects: (response: IApiResponse) => [
-        put(projectAssignmentGetAllSuccess(response.body)),
-        put(listBarMetadata(response.body.metadata))
+        put(projectAssignmentGetAllSuccess(response.body))
       ],
       failureEffects: (response: IApiResponse) => [
         put(projectAssignmentGetAllError(response.body)),
@@ -48,7 +48,9 @@ function* watchGetAllRequest() {
           })
         )
       ],
-      finallyEffects: [put(listBarLoading(false))]
+      finallyEffects: [
+        // nothing
+      ]
     });
   };
 
@@ -126,7 +128,8 @@ function* watchPatchRequest() {
       path: `/v1/project/assignments/${action.payload.companyUid}/${action.payload.projectUid}`,
       payload: action.payload.data,
       successEffects: (response: IApiResponse) => [
-        put(projectAssignmentPatchSuccess(response.body))
+        put(projectAssignmentPatchSuccess(response.body)),
+        put(projectAssignmentGetAllDispose())
       ],
       successCallback: (response: IApiResponse) => {
         action.payload.resolve(response.body.data);

--- a/src/modules/project/store/sagas/projectRegistrationSagas.ts
+++ b/src/modules/project/store/sagas/projectRegistrationSagas.ts
@@ -1,4 +1,5 @@
-import { layoutAlertAdd, listBarLoading, listBarMetadata } from '@layout/store/actions';
+import { projectGetAllDispose } from '@common/store/actions';
+import { layoutAlertAdd } from '@layout/store/actions';
 import {
   ProjectRegistrationAction as Action,
   projectRegistrationGetAllError,
@@ -30,7 +31,6 @@ function* watchGetAllRequest() {
       path: `/v1/project/registrations/${action.payload.companyUid}/${action.payload.positionUid}${objectToQuerystring(action.payload.filter)}`,
       successEffects: (response: IApiResponse) => [
         put(projectRegistrationGetAllSuccess(response.body)),
-        put(listBarMetadata(response.body.metadata))
       ],
       failureEffects: (response: IApiResponse) => [
         put(projectRegistrationGetAllError(response.body)),
@@ -51,7 +51,9 @@ function* watchGetAllRequest() {
           })
         )
       ],
-      finallyEffects: [put(listBarLoading(false))]
+      finallyEffects: [
+        // nothing
+      ]
     });
   };
 
@@ -129,7 +131,8 @@ function* watchPostRequest() {
       path: `/v1/project/registrations/${action.payload.companyUid}/${action.payload.positionUid}`,
       payload: action.payload.data,
       successEffects: (response: IApiResponse) => [
-        put(projectRegistrationPostSuccess(response.body))
+        put(projectRegistrationPostSuccess(response.body)),
+        put(projectGetAllDispose())
       ],
       successCallback: (response: IApiResponse) => {
         action.payload.resolve(response.body.data);
@@ -174,7 +177,8 @@ function* watchPutRequest() {
       path: `/v1/project/registrations/${action.payload.companyUid}/${action.payload.positionUid}/${action.payload.projectUid}`,
       payload: action.payload.data,
       successEffects: (response: IApiResponse) => [
-        put(projectRegistrationPutSuccess(response.body))
+        put(projectRegistrationPutSuccess(response.body)),
+        put(projectGetAllDispose())
       ],
       successCallback: (response: IApiResponse) => {
         action.payload.resolve(response.body.data);

--- a/src/playground/pages/DemoCollectionPage.tsx
+++ b/src/playground/pages/DemoCollectionPage.tsx
@@ -105,8 +105,8 @@ const config: CollectionConfig<IProject, AllProps> = {
       }
     }
   },
-  onUpdated: (states: AllProps, callback: CollectionHandler) => {
-    const { isLoading, response } = states.projectRegisterState.all;
+  onUpdated: (props: AllProps, callback: CollectionHandler) => {
+    const { isLoading, response } = props.projectRegisterState.all;
     
     callback.handleLoading(isLoading);
     callback.handleResponse(response);

--- a/src/playground/pages/DemoSinglePage.tsx
+++ b/src/playground/pages/DemoSinglePage.tsx
@@ -76,8 +76,8 @@ const config: SingleConfig<IProjectDetail, AllProps> = {
       }
     }
   },
-  onUpdated: (states: AllProps, callback: SingleHandler) => {
-    const { isLoading, response } = states.projectRegisterState.detail;
+  onUpdated: (props: AllProps, callback: SingleHandler) => {
+    const { isLoading, response } = props.projectRegisterState.detail;
     
     callback.handleLoading(isLoading);
     callback.handleResponse(response);


### PR DESCRIPTION
When a request has been modified or approval was submitted, loaded detail must be refreshed and previous loaded list must be cleared, then when user back to list, the page must refresh with new list data.